### PR TITLE
Fix submodule deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -24,16 +24,16 @@ jobs:
           extended: true
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 16
 
       - name: Install tools
         run: |
           sudo apt install curl jq
           npm i -g postcss postcss-cli autoprefixer
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: /tmp/hugo_cache
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
There are 2 commits.

@duncdrum Could you have a look at the first one? All the changes comes from the `git clone --recurse-submodules --remote-submodules https://github.com/readchina/comics.git` command after I deleted the existed local directory and re-cloned it with the git command.

The second commit is just to update a few action versions.

see #46 #49 